### PR TITLE
Fix `cljfmt` step: call `check`, not `fix`

### DIFF
--- a/.github/workflows/clojure-pr-check.yaml
+++ b/.github/workflows/clojure-pr-check.yaml
@@ -45,7 +45,7 @@ jobs:
         run: clojure -P
 
       - name: Run cljfmt
-        run: cljfmt fix
+        run: cljfmt check
 
       - name: Run clj-kondo (benchmarks)
         run: clj-kondo --lint benchmarks

--- a/src/effective_chainsaw/api.clj
+++ b/src/effective_chainsaw/api.clj
@@ -34,10 +34,10 @@
 
       (<= context-length max-context-length)
       (common/merge-bytes
-        (common/integer->byte-array 0 1)
-        (common/integer->byte-array context-length 1)
-        context
-        M)
+       (common/integer->byte-array 0 1)
+       (common/integer->byte-array context-length 1)
+       context
+       M)
 
       :else
       (throw (GeneralSecurityException. (format "Context length must be < %s bytes"


### PR DESCRIPTION
As of now when `fix` fixes a file it returns 0, but that's not the intended behavior: we want to fail the step (and the job).